### PR TITLE
fix: VRChatインストールフォルダ探索処理の修正

### DIFF
--- a/cmd/splashscreen-changer/args.go
+++ b/cmd/splashscreen-changer/args.go
@@ -92,7 +92,7 @@ func getDestinationPath(config *Config) (string, error) {
 
 	vrchatPath, err := findSteamGameDirectory("VRChat")
 	if err != nil {
-		return vrchatPath, nil
+		return "", errorRequired
 	}
 
 	_, err = os.Stat(filepath.Join(vrchatPath, "EasyAntiCheat"))
@@ -100,5 +100,5 @@ func getDestinationPath(config *Config) (string, error) {
 		return "", fmt.Errorf("EasyAntiCheat folder not found in %s", vrchatPath)
 	}
 
-	return "", errorRequired
+	return vrchatPath, nil
 }


### PR DESCRIPTION
EasyAntiCheatフォルダの存在確認処理が正常に動いていなかったので修正。

- close #35