### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/
+config.yaml
+config.yml


### PR DESCRIPTION
## 概要

`git worktree` 作成時にローカル専用の設定ファイルを引き継ぐための `.worktreeinclude` を追加しました。

## 追加したパターン

- `data/`
- `config.yaml`
- `config.yml`

## 根拠

- `.gitignore` に `test/`・`data/` の除外エントリがあり、`data/config.yml`（または任意配置の `config.yaml`）はローカル動作確認用の設定ファイルとして使われている。
- `CLAUDE.md` に「Config file path itself: `-config` flag or `CONFIG_PATH` env var, defaulting to `data/config.yml` next to the executable」との記載があり、実運用上 env var もしくは config file 経由での指定が前提になっている。
- `config.yaml.sample` は Windows 環境固有のパスを含むテンプレートであり、開発者がローカルで複製・編集して使う想定になっている。
- `.env` の gitignore エントリはコード中に dotenv 系の読み込み実装が見当たらず未使用のボイラープレートと判断し、対象から除外した。

## 関連

- https://github.com/book000/book000/issues/132